### PR TITLE
only buttons from settings if available

### DIFF
--- a/src/init.ts
+++ b/src/init.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { getPackageJson } from './packageJson'
+import { getPackageJson } from './packageJson';
 
 interface RunButton {
 	command: string,
@@ -32,7 +32,7 @@ const init =  async (context: vscode.ExtensionContext) => {
 		commands.push(...cmd)
 	}
 
-	if (typeof packageJson !== 'undefined') {
+	if (typeof packageJson !== 'undefined' && !config) {
 		const { scripts } = packageJson
 		let keys = Object.keys(scripts);
 	


### PR DESCRIPTION
Would be nice to display only the buttons defined in the settings, and not all of the buttons created from the package.json scripts
// Right now, it ignores the settings buttons and displays scripts from package.json