### PR TITLE
Use more passive message when project has no actions

### DIFF
--- a/src/init.ts
+++ b/src/init.ts
@@ -127,8 +127,9 @@ const init = async (context: vscode.ExtensionContext) => {
 			}
 		)
 	} else {
-		vscode.window.showInformationMessage(
-			'VsCode Action Buttons: You have no run commands '
+		vscode.window.setStatusBarMessage(
+			'VsCode Action Buttons: You have no run commands.',
+			4000
 		)
 	}
 }


### PR DESCRIPTION
![](https://user-images.githubusercontent.com/50426566/77369421-f850e700-6d34-11ea-8620-bf59c2037e4a.png)

Currently, the pictured message must be dismissed upon opening VSCode in any directory that does not have actions set up. One cannot expect users to have actions in every directory that they use VSCode with, and dismissing this message every time the editor is opened can become tedious. This message is not urgent enough to require action from the user, as an alert like showInformationMessage does.

This change aims to make the message more passive by making it a status bar message that automatically disposes itself after 4 seconds.