### PR TITLE
Add tooltip option for commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,10 @@
 										"type": "string",
 										"markdownDescription": "Command to execute when action is activated.\n\nIf `useVsCodeApi` is `true`, this is the VS Code command to execute. Otherwise, this specifies the command to execute in the terminal"
 									},
+									"tooltip": {
+										"type": "string",
+										"markdownDescription": "Tooltip text to display when hovering over the button"
+									},
 									"color": {
 										"type": "string",
 										"markdownDescription": "Specifies the action button text color"

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,6 +1,6 @@
 import { buildConfigFromPackageJson } from './packageJson'
 import * as vscode from 'vscode'
-import { CommandOpts } from './types'
+import { ButtonOpts, CommandOpts } from './types'
 import * as path from 'path'
 
 const registerCommand = vscode.commands.registerCommand
@@ -14,14 +14,14 @@ const init = async (context: vscode.ExtensionContext) => {
 	const reloadButton = config.get<string>('reloadButton')
 	const loadNpmCommands = config.get<boolean>('loadNpmCommands')
 	const cmds = config.get<CommandOpts[]>('commands')
-	const commands = []
+	const commands: CommandOpts[] = []
 
 	if (reloadButton !== null) {
 		loadButton({
-			vsCommand: 'extension.refreshButtons',
+			command: 'extension.refreshButtons',
 			name: reloadButton,
-			color: defaultColor,
-			command: 'Refreshes the action buttons'
+			tooltip: 'Refreshes the action buttons',
+			color: defaultColor
 		})
 	}
 	else {
@@ -43,7 +43,7 @@ const init = async (context: vscode.ExtensionContext) => {
 	if (commands.length) {
 		const terminals: { [name: string]: vscode.Terminal } = {}
 		commands.forEach(
-			({ cwd, command, name, color, singleInstance, focus, useVsCodeApi }: CommandOpts) => {
+			({ cwd, command, name, tooltip, color, singleInstance, focus, useVsCodeApi }: CommandOpts) => {
 				const vsCommand = `extension.${name.replace(' ', '')}`
 
 				const disposable = registerCommand(vsCommand, async () => {
@@ -116,9 +116,9 @@ const init = async (context: vscode.ExtensionContext) => {
 				disposables.push(disposable)
 
 				loadButton({
-					vsCommand,
-					command,
+					command: vsCommand,
 					name,
+					tooltip: tooltip || command,
 					color: color || defaultColor,
 				})
 			}
@@ -134,15 +134,15 @@ const init = async (context: vscode.ExtensionContext) => {
 function loadButton({
 	command,
 	name,
+	tooltip,
 	color,
-	vsCommand
-}: CommandOpts) {
+}: ButtonOpts) {
 	const runButton = vscode.window.createStatusBarItem(1, 0)
 	runButton.text = name
 	runButton.color = color
-	runButton.tooltip = command
+	runButton.tooltip = tooltip
 
-	runButton.command = vsCommand
+	runButton.command = command
 	runButton.show()
 	disposables.push(runButton)
 }

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,6 +1,6 @@
 import { buildConfigFromPackageJson } from './packageJson'
 import * as vscode from 'vscode'
-import { RunButton } from './types'
+import { CommandOpts } from './types'
 import * as path from 'path'
 
 const registerCommand = vscode.commands.registerCommand
@@ -13,7 +13,7 @@ const init = async (context: vscode.ExtensionContext) => {
 	const defaultColor = config.get<string>('defaultColor')
 	const reloadButton = config.get<string>('reloadButton')
 	const loadNpmCommands = config.get<boolean>('loadNpmCommands')
-	const cmds = config.get<RunButton[]>('commands')
+	const cmds = config.get<CommandOpts[]>('commands')
 	const commands = []
 
 	if (reloadButton !== null) {
@@ -43,7 +43,7 @@ const init = async (context: vscode.ExtensionContext) => {
 	if (commands.length) {
 		const terminals: { [name: string]: vscode.Terminal } = {}
 		commands.forEach(
-			({ cwd, command, name, color, singleInstance, focus, useVsCodeApi }: RunButton) => {
+			({ cwd, command, name, color, singleInstance, focus, useVsCodeApi }: CommandOpts) => {
 				const vsCommand = `extension.${name.replace(' ', '')}`
 
 				const disposable = registerCommand(vsCommand, async () => {
@@ -136,7 +136,7 @@ function loadButton({
 	name,
 	color,
 	vsCommand
-}: RunButton) {
+}: CommandOpts) {
 	const runButton = vscode.window.createStatusBarItem(1, 0)
 	runButton.text = name
 	runButton.color = color

--- a/src/packageJson.ts
+++ b/src/packageJson.ts
@@ -1,4 +1,4 @@
-import { RunButton } from './types'
+import { CommandOpts } from './types'
 import { workspace } from 'vscode'
 
 export const getPackageJson = async (): Promise<undefined | any> =>
@@ -26,5 +26,5 @@ export const buildConfigFromPackageJson = async (defaultColor: string) => {
 		color: defaultColor || 'white',
 		name: key,
 		singleInstance: true
-	})) as RunButton[]
+	})) as CommandOpts[]
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ export interface CommandOpts {
 	command: string
 	singleInstance?: boolean
 	name: string
+	tooltip: string
 	color: string
 	focus?: boolean
 	useVsCodeApi?: boolean

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,6 @@
-export interface RunButton {
+export interface CommandOpts {
 	cwd?: string
 	command: string
-	vsCommand: string
 	singleInstance?: boolean
 	name: string
 	color: string

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,13 @@ export interface RunButton {
 	singleInstance?: boolean
 	name: string
 	color: string
-	focus?: string
+	focus?: boolean
 	useVsCodeApi?: boolean
+}
+
+export interface ButtonOpts {
+	command: string
+	tooltip: string
+	name: string
+	color: string
 }


### PR DESCRIPTION
Add option to specify the tooltip that appears when hovering over the action button. If not specified, this defaults to the command option (which was the previous tooltip always).

**Demo**

![Tooltip 3](https://user-images.githubusercontent.com/1342819/144910457-1cfb84a3-8d28-47ee-9e23-d6a7607f3192.gif)

**Note: This depends on https://github.com/seunlanlege/vscode-action-buttons/pull/64. Do not merge until that is merged.**

Fixes #54 