### PR TITLE
add 'saveAll' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Add customizable buttons to the status bar to execute actions or tasks in VS Cod
 
 * **name**
     * Name of the action button. This field is required.
+* **saveAll**
+	* Save all open files before execute command
 * **command**
     * Command to execute when action is activated. This field is required.
 	* If `useVsCodeApi` is `true`, this is the VS Code command to execute. Otherwise, this specifies the command to execute in the terminal

--- a/package.json
+++ b/package.json
@@ -60,6 +60,11 @@
 										"type": "string",
 										"markdownDescription": "Name of the action button"
 									},
+									"saveAll": {
+										"type": "boolean",
+										"markdownDescription": "Save all open files before execute command"
+
+									},
 									"command": {
 										"type": "string",
 										"markdownDescription": "Command to execute when action is activated.\n\nIf `useVsCodeApi` is `true`, this is the VS Code command to execute. Otherwise, this specifies the command to execute in the terminal"

--- a/src/init.ts
+++ b/src/init.ts
@@ -43,7 +43,7 @@ const init = async (context: vscode.ExtensionContext) => {
 	if (commands.length) {
 		const terminals: { [name: string]: vscode.Terminal } = {}
 		commands.forEach(
-			({ cwd, command, name, tooltip, color, singleInstance, focus, useVsCodeApi, args }: CommandOpts) => {
+			({ cwd, saveAll, command, name, tooltip, color, singleInstance, focus, useVsCodeApi, args }: CommandOpts) => {
 				const vsCommand = `extension.${name.replace(' ', '')}`
 
 				const disposable = registerCommand(vsCommand, async () => {
@@ -92,6 +92,10 @@ const init = async (context: vscode.ExtensionContext) => {
 					if (!command) {
 						vscode.window.showErrorMessage('No command to execute for this action');
 						return;
+					}
+
+					if (saveAll) {
+						vscode.commands.executeCommand('workbench.action.files.saveAll');
 					}
 
 					if (useVsCodeApi) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 export interface CommandOpts {
 	cwd?: string
+	saveAll?: boolean
 	command: string
 	singleInstance?: boolean
 	name: string


### PR DESCRIPTION
Add 'saveAll' option for save all open files before execute command.

How to use:
 "commands": [
            {
                "cwd": "${workspaceFolder}/build", 
                "name": "Build",
                "color": "white",
                "singleInstance": false,
                "saveAll": true,
                "command": "make -j4"
            },
]