### PR TITLE
Fixed #80 - #95 - Added two options to manage terminals

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,11 @@
 										"type": "string",
 										"markdownDescription": "Start directory when executing terminal command\n\nOnly valid when `useVsCodeApi` is `false`"
 									},
+									"openOwnTerminal": {
+										"type": "boolean",
+										"default": true,
+										"markdownDescription": "Execute the command on it's own terminal. If false, the command will be executed in the first active terminal that has not be opened by other commands.\n\nOnly valid when `useVsCodeApi` is `false`\n\nThis is True by default"
+									},
 									"singleInstance": {
 										"type": "boolean",
 										"default": false,
@@ -90,6 +95,11 @@
 										"type": "boolean",
 										"default": false,
 										"markdownDescription": "Focus the terminal after executing the command.\n\nOnly valid when `useVsCodeApi` is `false`"
+									},
+									"closeOnSuccess": {
+										"type": "boolean",
+										"default": false,
+										"markdownDescription": "Close the terminal if the command is successfully executed\n\nOnly valid when `useVsCodeApi` is `false`"
 									},
 									"useVsCodeApi": {
 										"type": "boolean",

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,11 +2,13 @@ export interface CommandOpts {
 	cwd?: string
 	saveAll?: boolean
 	command: string
+	openOwnTerminal?: boolean
 	singleInstance?: boolean
 	name: string
 	tooltip: string
 	color: string
 	focus?: boolean
+	closeOnSuccess?: boolean
 	useVsCodeApi?: boolean
 	args?: string[]
 }


### PR DESCRIPTION
Closes #80 and #95 
I found useful to have an option "closeOnSuccess", which if set to true, close the terminal after the command is successfully executed. If the command return an exit status not equal to 0 (!=0 means error), the terminal stays open to let the user to see what happened.