### PR TITLE
Add toggleGroupButton and per-command group option

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Add customizable buttons to the status bar to execute actions or tasks in VS Cod
 
 * **reloadButton**
     * Text for reload actions button. Defaults to `↻`. If null, the reload button is disabled.
+* **toggleGroupButton**
+    * Text for a button that cycles which command groups are shown. Defaults to `null` (disabled). Only appears when at least one command defines a `group`. Clicking it cycles through `all` → each group → `none` (ungrouped only); with a single group it acts as a simple full/minimal toggle. See the `group` command option below.
 * **defaultColor**
     * Default text color of action buttons. Defaults to `white`. To set default theme color type `none`.
 * **loadNpmCommands**
@@ -85,6 +87,8 @@ Add customizable buttons to the status bar to execute actions or tasks in VS Cod
     * Specifies whether to execute a VS Code command or terminal command. Defaults to `false`.
 * **args**
     * Specifies additional arguments to pass to VS Code command. Only valid when `useVsCodeApi` is `true`.
+* **group**
+    * Optional tag that assigns the button to a group. Ungrouped buttons are always visible; grouped buttons are shown or hidden by the `toggleGroupButton` cycle. Useful for keeping project-specific buttons separate from ones you use everywhere.
 
 ## Usage
 
@@ -121,6 +125,9 @@ As seen in the previous example, vars such as `${file}` can be used. Below is a 
 * `execPath` - the path to the running VS Code executable
 
 ## Release Notes
+
+### v1.3.0
+Added `toggleGroupButton` and per-command `group` options for showing/hiding groups of buttons.
 
 ### v1.2.2
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "action-buttons",
 	"displayName": "VsCode Action Buttons",
 	"description": "Add customizable buttons to the status bar to execute actions or tasks",
-	"version": "1.2.3",
+	"version": "1.3.0",
 	"publisher": "seunlanlege",
 	"repository": {
 		"type": "git",
@@ -30,6 +30,10 @@
 			{
 				"command": "extension.refreshButtons",
 				"title": "Refresh Action Buttons"
+			},
+			{
+				"command": "extension.cycleButtonGroup",
+				"title": "Cycle Action Button Group"
 			}
 		],
 		"configuration": {
@@ -103,6 +107,10 @@
 										},
 										"default": [],
 										"markdownDescription": "List of arguments passed to VS Code command\n\nOnly valid when `useVsCodeApi` is `true`"
+									},
+									"group": {
+										"type": "string",
+										"markdownDescription": "Optional group tag; ungrouped = always visible"
 									}
 								}
 							}
@@ -121,6 +129,12 @@
 							"required": false,
 							"default": "↻",
 							"markdownDescription": "Reload button text. If `null`, button is disabled"
+						},
+						"toggleGroupButton": {
+							"type": [ "string", "null"],
+							"required": false,
+							"default": null,
+							"markdownDescription": "Toggle group button text. If `null`, button is disabled with no effect on behaviour"
 						},
 						"loadNpmCommands": {
 							"type": "boolean",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,12 +5,22 @@ import init from './init'
 export function activate(context: vscode.ExtensionContext) {
 	init(context)
 
-	let disposable = vscode.commands.registerCommand(
+	const refreshButtons = vscode.commands.registerCommand(
 		'extension.refreshButtons',
 		() => init(context)
 	)
 
-	context.subscriptions.push(disposable)
+	const cycleButtonGroup = vscode.commands.registerCommand(
+		'extension.cycleButtonGroup', async () => {
+			const cycle = context.workspaceState.get<string[]>('actionButtons.groupCycle', ['all', 'none'])
+			const current = context.workspaceState.get<string>('actionButtons.activeGroup', 'all')
+			const next = cycle[(cycle.indexOf(current) + 1) % cycle.length]
+			await context.workspaceState.update('actionButtons.activeGroup', next)
+			init(context)
+		}
+	)
+
+	context.subscriptions.push(refreshButtons, cycleButtonGroup)
 }
 
 // this method is called when your extension is deactivated

--- a/src/init.ts
+++ b/src/init.ts
@@ -14,6 +14,8 @@ const init = async (context: vscode.ExtensionContext) => {
 	const reloadButton = config.get<string>('reloadButton')
 	const loadNpmCommands = config.get<boolean>('loadNpmCommands')
 	const inheritGlobalCommands = config.get<boolean>('inheritGlobalCommands')
+	const toggleGroupButton = config.get<string>('toggleGroupButton') // e.g. ">> View". null/undefined = disabled
+	const activeGroup = context.workspaceState.get<string>('actionButtons.activeGroup', 'all')
 	const cmds = config.get<CommandOpts[]>('commands')
 	const commands: CommandOpts[] = []
 
@@ -48,10 +50,36 @@ const init = async (context: vscode.ExtensionContext) => {
 	}
 
 	if (loadNpmCommands !== false) commands.push(...(await buildConfigFromPackageJson(defaultColor)))
+	
+	const groups = [...new Set(commands.map(c => c.group).filter(Boolean))]
+
+	// Binary (full <-> minimal) when 0-1 groups; multi-way cycle when 2+.
+	// Persist it so the cycle command shares init's merged view of the groups.
+	const cycle = groups.length > 1 ? ['all', ...groups, 'none'] : ['all', 'none']
+	context.workspaceState.update('actionButtons.groupCycle', cycle)
+
+	// When the toggle button is disabled, never hide anything - this avoids a
+	// lockout if the user disables it while a non-'all' group is still persisted.
+	const effectiveGroup = toggleGroupButton ? activeGroup : 'all'
+
+	// Add the cycle/toggle button, mirroring how the reload button is added
+	if (toggleGroupButton && groups.length) {
+		loadButton({
+			command: 'extension.cycleButtonGroup',
+			name: `${toggleGroupButton} (${activeGroup})`,
+			tooltip: 'Cycles visible action-button groups: ' + groups.join(', '),
+			color: defaultColor,
+		})
+	}
+
+	// Ungrouped always visible; grouped buttons only when active or "all"
+	const visibleCommands = commands.filter(c =>
+		!c.group || effectiveGroup === 'all' || c.group === effectiveGroup
+	)
 
 	if (commands.length) {
 		const terminals: { [name: string]: vscode.Terminal } = {}
-		commands.forEach(
+		visibleCommands.forEach(
 			({ cwd, saveAll, command, name, tooltip, color, singleInstance, focus, useVsCodeApi, args }: CommandOpts) => {
 				const vsCommand = `extension.${name.replace(' ', '')}`
 

--- a/src/init.ts
+++ b/src/init.ts
@@ -62,11 +62,14 @@ const init = async (context: vscode.ExtensionContext) => {
 	// lockout if the user disables it while a non-'all' group is still persisted.
 	const effectiveGroup = toggleGroupButton ? activeGroup : 'all'
 
-	// Add the cycle/toggle button, mirroring how the reload button is added
+	// Add the cycle/toggle button, mirroring how the reload button is added.
+	// Only annotate with the active group in the multi-way cycle; a binary
+	// full/minimal toggle has no meaningful group name to show.
 	if (toggleGroupButton && groups.length) {
+		const name = groups.length > 1 ? `${toggleGroupButton} (${activeGroup})` : toggleGroupButton
 		loadButton({
 			command: 'extension.cycleButtonGroup',
-			name: `${toggleGroupButton} (${activeGroup})`,
+			name,
 			tooltip: 'Cycles visible action-button groups: ' + groups.join(', '),
 			color: defaultColor,
 		})

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,7 @@ export interface CommandOpts {
 	focus?: boolean
 	useVsCodeApi?: boolean
 	args?: string[]
+	group?: string				// NEW: optional group tag; ungrouped = always visible
 }
 
 export interface ButtonOpts {


### PR DESCRIPTION
## Summary
Adds an optional `group` tag on individual commands and a `toggleGroupButton`
status-bar button that cycles which groups are visible. Lets users declutter the
status bar when they've defined many buttons, without removing any config.

- Ungrouped buttons are always visible.
- With a single group defined, the toggle is a simple full/minimal switch
  (button shows just the toggle text).
- With 2+ groups, it cycles through each group individually
  (`all → group A → group B → none`), annotating the button with the active
  group so you can tell where you are.
- `toggleGroupButton` defaults to `null`, so existing configs are unaffected —
  nothing is ever hidden unless the button is explicitly enabled.

## Config example
```json
"actionButtons": {
  "toggleGroupButton": "☰",
  "commands": [
    { "name": "Always A", "command": "echo Always A" },
    { "name": "Build",    "command": "echo Build",  "group": "build" },
    { "name": "Test",     "command": "echo Test",   "group": "build" },
    { "name": "Deploy",   "command": "echo Deploy", "group": "release" }
  ]
}
```
Clicking `☰` cycles: all buttons → only `build` → only `release` → only
ungrouped (`Always A`). `Always A` stays visible throughout.

## Related issues
Relates to #111 (status-bar clutter with many buttons) and #88 (wanting
per-project button visibility). This doesn't fully solve either — there's no
automatic/context-aware hiding — but it gives users a manual way to cut down on
visible buttons.

## Test plan
- [x] `tsc --noEmit` passes
- [x] Toggling with a single group behaves as a full/minimal switch
- [x] Toggling with 2+ groups cycles through each group and back
- [x] Configs without `group`/`toggleGroupButton` behave exactly as before
